### PR TITLE
remove pollution law

### DIFF
--- a/drafts/Administration_of_Justice.md
+++ b/drafts/Administration_of_Justice.md
@@ -148,11 +148,6 @@
 * i) Definition: Public nuisance is behaving in a manner which interferes with the rights of other people to use and/or enjoy public space.
 * ii) Sentencing: c. 
 
-#### Polluting environment
-
-* i) Definition: Polluting environment is causing pollution of the green areas, water, air, ground, including underground, of the Free Republic of Liberland.
-* ii) Sentencing: c. 
-
 #### Disregarding a court order
 
 * i) Definition: Disregarding a court order is acting with intention or negligently in a manner which amounts to the breach of a court order affecting the defendant.


### PR DESCRIPTION
This law is not necessary. All property is owned, whether by private entities or by the government of Liberland (capitol grounds for instance). Pollution in these casess is covered under the law that covers Damage to property.

In a free society, pollution is largely a civil matter. If I damage somebody else's property by polluting it, the courts can determine appropriate compensation. In rare instances where it rises to the level of criminal negligence (my laboratory releases a toxic cloud and kills people) it can and should be punished as a criminal matter with appropriate penalties and compensation to the victims.