### PR TITLE
Replace Pollution law with International Waters Draft

### DIFF
--- a/drafts/Administration_of_Justice.md
+++ b/drafts/Administration_of_Justice.md
@@ -148,11 +148,6 @@
 * i) Definition: Public nuisance is behaving in a manner which interferes with the rights of other people to use and/or enjoy public space.
 * ii) Sentencing: c. 
 
-#### Polluting environment
-
-* i) Definition: Polluting environment is causing pollution of the green areas, water, air, ground, including underground, of the Free Republic of Liberland.
-* ii) Sentencing: c. 
-
 #### Disregarding a court order
 
 * i) Definition: Disregarding a court order is acting with intention or negligently in a manner which amounts to the breach of a court order affecting the defendant.

--- a/drafts/International Waters and Waterways
+++ b/drafts/International Waters and Waterways
@@ -1,0 +1,9 @@
+# International Waterwayss
+
+1. The usage of International Waters and Waterways by persons and entities inside the Free Republic of Liberland is subject to agreed upon treaties between the Free Republic of Liberland and other nations of the world. 
+
+2. No person or entity may pollute, draw from, use or interact with an international waterway or body of water except where allowed by international treaty.
+
+3. The legislature is responsible for administering the use of international waterways and bodies of water which are subject to international treaties to which the Free Republic of Liberland is bound.
+
+4. The legislature may enact policy governing the usage of such waterways and bodies of water only as needed to assure compliance with treaty requirements.

--- a/drafts/International Waters and Waterways
+++ b/drafts/International Waters and Waterways
@@ -1,4 +1,4 @@
-# International Waterwayss
+# International Waterways
 
 1. The usage of International Waters and Waterways by persons and entities inside the Free Republic of Liberland is subject to agreed upon treaties between the Free Republic of Liberland and other nations of the world. 
 


### PR DESCRIPTION
The primary reason for the pollution law was to protect the Danube as it is an International body of water. That protection is better served by a draft concerning International Waters and Waterways.

The pollution law was too broad and could be used to prohibit a wide range of activities, bringing it into conflict with the Constitution.